### PR TITLE
Adds --diff to the isort command

### DIFF
--- a/build
+++ b/build
@@ -34,6 +34,7 @@ yapf \
 isort \
   --recursive \
   --force-single-line-imports \
+  --diff \
   --check-only \
   --skip-glob=third_party/* \
   --skip-glob=venv/*


### PR DESCRIPTION
It turns out that --diff and --check-only set the proper exit code:

https://github.com/timothycrosley/isort/issues/1039#issuecomment-559336497