### PR TITLE
Remove --exclude flag from YAPF

### DIFF
--- a/dev-scripts/build-python
+++ b/dev-scripts/build-python
@@ -30,7 +30,7 @@ coverage run \
 coverage report
 
 # Check that source has correct formatting.
-yapf --diff --recursive --exclude=venv/* ./
+yapf --diff --recursive ./
 
 # Check correct sorting for imports.
 isort \


### PR DESCRIPTION
We're already excluding the directory through .yapfignore, so we don't need to exclude it with a flag, too.